### PR TITLE
Persist manager nbt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ dependencies {
     runtimeOnly "curse.maven:CoFHWorld-271384:2920434"
     runtimeOnly "curse.maven:RedstoneFlux-270789:2920436"
     runtimeOnly "curse.maven:CodeChickenLib-242818:2779848"
+    runtimeOnly "curse.maven:had-enough-items-557549:4543375"
     //
     embed 'org.javassist:javassist:3.28.0-GA'
     // Kotlin stuff

--- a/src/main/java/com/tom/logisticsbridge/pipe/CraftingManager.java
+++ b/src/main/java/com/tom/logisticsbridge/pipe/CraftingManager.java
@@ -281,19 +281,23 @@ public class CraftingManager extends PipeLogisticsChassis implements IIdPipe {
             IItemIdentifierInventory moduleInventory = (IItemIdentifierInventory) getModuleInventory();
             for (int i = 0; i < getChassisSize(); i++) {
                 ItemIdentifierStack idStack = moduleInventory.getIDStackInSlot(i);
-                if (idStack != null) {
-                    final Item stackItem = idStack.getItem().item;
-                    if (stackItem instanceof ItemModule) {
-                        final ItemModule moduleItem = (ItemModule) stackItem;
-                        ModuleCrafterExt crafterExt = new ModuleCrafterExt();
-                        crafterExt.registerHandler(this, this);
-                        crafterExt.registerPosition(ModulePositionType.SLOT, i);
-                        ItemModuleInformationManager.readInformation(moduleInventory.getStackInSlot(i), crafterExt);
-                        if (crafterExt != null) {
-                            modules.installModule(i, crafterExt);
-                        }
-                    }
+
+                ItemModule moduleItem = Optional.ofNullable(idStack)
+                        .map(ItemIdentifierStack::getItem)
+                        .map(it -> it.item)
+                        .filter(it -> it instanceof ItemModule)
+                        .map(ItemModule.class::cast)
+                        .orElse(null);
+
+                if (moduleItem == null) {
+                    continue;
                 }
+
+                ModuleCrafterExt crafterExt = new ModuleCrafterExt();
+                crafterExt.registerHandler(this, this);
+                crafterExt.registerPosition(ModulePositionType.SLOT, i);
+                ItemModuleInformationManager.readInformation(moduleInventory.getStackInSlot(i), crafterExt);
+                modules.installModule(i, crafterExt);
             }
 
             resultId = nbttagcompound.getString("resultname");

--- a/src/main/java/com/tom/logisticsbridge/pipe/CraftingManager.java
+++ b/src/main/java/com/tom/logisticsbridge/pipe/CraftingManager.java
@@ -46,6 +46,7 @@ import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import network.rs485.logisticspipes.connection.LPNeighborTileEntityKt;
+import network.rs485.logisticspipes.inventory.IItemIdentifierInventory;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
@@ -147,16 +148,20 @@ public class CraftingManager extends PipeLogisticsChassis implements IIdPipe {
     }
 
     @Override
-    public void startWatching() { }
+    public void startWatching() {
+    }
 
     @Override
-    public void stopWatching() { }
+    public void stopWatching() {
+    }
 
     @Override
-    public void playerStartWatching(EntityPlayer player, int mode) { }
+    public void playerStartWatching(EntityPlayer player, int mode) {
+    }
 
     @Override
-    public void playerStopWatching(EntityPlayer player, int mode) { }
+    public void playerStopWatching(EntityPlayer player, int mode) {
+    }
 
     @Override
     public boolean handleClick(EntityPlayer entityplayer, SecuritySettings settings) {
@@ -271,6 +276,26 @@ public class CraftingManager extends PipeLogisticsChassis implements IIdPipe {
         try {
             readingNBT = true;
             super.readFromNBT(nbttagcompound);
+            ChassisModule modules = getModules();
+
+            IItemIdentifierInventory moduleInventory = (IItemIdentifierInventory) getModuleInventory();
+            for (int i = 0; i < getChassisSize(); i++) {
+                ItemIdentifierStack idStack = moduleInventory.getIDStackInSlot(i);
+                if (idStack != null) {
+                    final Item stackItem = idStack.getItem().item;
+                    if (stackItem instanceof ItemModule) {
+                        final ItemModule moduleItem = (ItemModule) stackItem;
+                        ModuleCrafterExt crafterExt = new ModuleCrafterExt();
+                        crafterExt.registerHandler(this, this);
+                        crafterExt.registerPosition(ModulePositionType.SLOT, i);
+                        ItemModuleInformationManager.readInformation(moduleInventory.getStackInSlot(i), crafterExt);
+                        if (crafterExt != null) {
+                            modules.installModule(i, crafterExt);
+                        }
+                    }
+                }
+            }
+
             resultId = nbttagcompound.getString("resultname");
             satelliteId = nbttagcompound.getString("satellitename");
             if (nbttagcompound.hasKey("resultid")) {
@@ -455,10 +480,10 @@ public class CraftingManager extends PipeLogisticsChassis implements IIdPipe {
                                 ItemStack removed = util.getMultipleItems(toSend.getItem(), toSend.getStackSize());
                                 if (removed != null && !removed.isEmpty()) {
                                     UUID moved;
-                                    if (getSatelliteRouterByID(en.getKey()) != null )
-                                         moved = en.getKey();
+                                    if (getSatelliteRouterByID(en.getKey()) != null)
+                                        moved = en.getKey();
                                     else
-                                         moved = getSatelliteUUID();
+                                        moved = getSatelliteUUID();
                                     sendStack(removed, SimpleServiceLocator.routerManager.getIDforUUID(moved), ItemSendMode.Fast, null, getPointedOrientation());
                                     maxDist = Math.max(maxDist, (int) getSatelliteRouterByID(moved).getPipe().getPos().distanceSq(getPos()));
                                 }


### PR DESCRIPTION
Whilst testing the LP base upgrade, it turned out Crafting Managers were not restoring the nbt of their crafts correctly when reloading a world.

The was due to inheriting from the previous LP implementation of readFromNBT which invoked InventoryChanged. It no longer does this, and that is where we replace ModuleCrafter for ModuleCrafterExt.

Extra processing was added in readFromNBT to mimic what was required from InventoryChanged