### PR TITLE
Using getServerRouter instead of getRouter when looking up satellites…

### DIFF
--- a/src/main/java/com/tom/logisticsbridge/module/ModuleCrafterExt.java
+++ b/src/main/java/com/tom/logisticsbridge/module/ModuleCrafterExt.java
@@ -156,25 +156,25 @@ public class ModuleCrafterExt extends ModuleCrafter {
     private IRouter getSatelliteRouter(int x) {
         final UUID satelliteUUID = x == -1 ? this.satelliteUUID.getValue() : advancedSatelliteUUIDList.get(x);
         final int satelliteRouterId = SimpleServiceLocator.routerManager.getIDforUUID(satelliteUUID);
-        return SimpleServiceLocator.routerManager.getRouter(satelliteRouterId);
+        return SimpleServiceLocator.routerManager.getServerRouter(satelliteRouterId);
     }
 
     private IRouter getFluidSatelliteRouter(int x) {
         final UUID liquidSatelliteUUID = x == -1 ? this.liquidSatelliteUUID.getValue() : liquidSatelliteUUIDList.get(x);
         final int satelliteRouterId = SimpleServiceLocator.routerManager.getIDforUUID(liquidSatelliteUUID);
-        return SimpleServiceLocator.routerManager.getRouter(satelliteRouterId);
+        return SimpleServiceLocator.routerManager.getServerRouter(satelliteRouterId);
     }
 
     public IRouter getSatelliteRouterByID(UUID id) {
         if (id == null) return null;
         int satelliteRouterId = SimpleServiceLocator.routerManager.getIDforUUID(id);
-        return SimpleServiceLocator.routerManager.getRouter(satelliteRouterId);
+        return SimpleServiceLocator.routerManager.getServerRouter(satelliteRouterId);
     }
 
     public IRouter getResultRouterByID(UUID id) {
         if (id == null) return null;
         int resultRouterId = SimpleServiceLocator.routerManager.getIDforUUID(id);
-        return SimpleServiceLocator.routerManager.getRouter(resultRouterId);
+        return SimpleServiceLocator.routerManager.getServerRouter(resultRouterId);
     }
 
     @Override


### PR DESCRIPTION
… using a CraftingManager. For some reason these two identical method calls are restricted by client vs server, and we were calling in a way that broke. LP crafts are done on the server and AE2 appears to be client side.